### PR TITLE
Use MessageResult to return error messages

### DIFF
--- a/MakiseSharpServer.API/Controllers/TokenController.cs
+++ b/MakiseSharpServer.API/Controllers/TokenController.cs
@@ -1,6 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using MakiseSharpServer.API.Results;
 using MakiseSharpServer.Application.ApiClients.Errors;
 using MakiseSharpServer.Application.Authentication.Commands.CreateToken;
 using MakiseSharpServer.Application.Authentication.Models;
@@ -28,12 +29,12 @@ namespace MakiseSharpServer.API.Controllers
 
             if (result.Errors.Any(e => e is UnavailableError))
             {
-                return new StatusCodeResult(503);
+                return new MessageResult(503, "Discord API is unavailable.");
             }
 
             if (result.Errors.Any(e => e is WrongAccessCodeError || e is ForbiddenError))
             {
-                return new UnauthorizedObjectResult("Wrong access code.");
+                return new MessageResult(401, "Wrong access code.");
             }
 
             return new StatusCodeResult(500);

--- a/MakiseSharpServer.API/Results/MessageResult.cs
+++ b/MakiseSharpServer.API/Results/MessageResult.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace MakiseSharpServer.API.Results
+{
+    public class MessageResult : ObjectResult
+    {
+        public MessageResult(int statusCode, string message)
+            : base(new { Message = message })
+        {
+            StatusCode = statusCode;
+        }
+    }
+}


### PR DESCRIPTION
Standard way to return 400+ status code messages