### PR TITLE
Add Swashbuckle

### DIFF
--- a/MakiseSharpServer.API/Controllers/TokenController.cs
+++ b/MakiseSharpServer.API/Controllers/TokenController.cs
@@ -20,6 +20,11 @@ namespace MakiseSharpServer.API.Controllers
             this.appSettings = appSettings;
         }
 
+        /// <summary>
+        /// Used to create a new JWT and a refresh token given a correct Discord API access token
+        /// </summary>
+        /// <param name="accessToken">Discord API access token</param>
+        /// <returns>JWT and refresh token</returns>
         [HttpPost]
         [SwaggerResponse(200, "Returns JWT with refresh token.")]
         [SwaggerResponse(401, "Wrong access code.")]

--- a/MakiseSharpServer.API/Controllers/TokenController.cs
+++ b/MakiseSharpServer.API/Controllers/TokenController.cs
@@ -6,6 +6,7 @@ using MakiseSharpServer.Application.Authentication.Commands.CreateToken;
 using MakiseSharpServer.Application.Authentication.Models;
 using MakiseSharpServer.Application.Settings;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace MakiseSharpServer.API.Controllers
 {
@@ -19,6 +20,10 @@ namespace MakiseSharpServer.API.Controllers
         }
 
         [HttpPost]
+        [SwaggerResponse(200, "Returns JWT with refresh token")]
+        [SwaggerResponse(401, "Wrong access code provided")]
+        [SwaggerResponse(500)]
+        [SwaggerResponse(503, "Discord API unavailable")]
         public async Task<ActionResult<JwtResponse>> CreateTokenAsync([Required] string accessToken)
         {
             var result = await Mediator.Send(new CreateTokenCommand(accessToken, appSettings.Discord.ClientId, appSettings.Discord.ClientSecret, appSettings.Discord.RedirectUri));

--- a/MakiseSharpServer.API/Controllers/TokenController.cs
+++ b/MakiseSharpServer.API/Controllers/TokenController.cs
@@ -18,6 +18,7 @@ namespace MakiseSharpServer.API.Controllers
             this.appSettings = appSettings;
         }
 
+        [HttpPost]
         public async Task<ActionResult<JwtResponse>> CreateTokenAsync([Required] string accessToken)
         {
             var result = await Mediator.Send(new CreateTokenCommand(accessToken, appSettings.Discord.ClientId, appSettings.Discord.ClientSecret, appSettings.Discord.RedirectUri));

--- a/MakiseSharpServer.API/Controllers/TokenController.cs
+++ b/MakiseSharpServer.API/Controllers/TokenController.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using MakiseSharpServer.API.Results;
@@ -21,10 +21,10 @@ namespace MakiseSharpServer.API.Controllers
         }
 
         [HttpPost]
-        [SwaggerResponse(200, "Returns JWT with refresh token")]
-        [SwaggerResponse(401, "Wrong access code provided")]
+        [SwaggerResponse(200, "Returns JWT with refresh token.")]
+        [SwaggerResponse(401, "Wrong access code.")]
         [SwaggerResponse(500)]
-        [SwaggerResponse(503, "Discord API unavailable")]
+        [SwaggerResponse(503, "Discord API is unavailable.")]
         public async Task<ActionResult<JwtResponse>> CreateTokenAsync([Required] string accessToken)
         {
             var result = await Mediator.Send(new CreateTokenCommand(accessToken, appSettings.Discord.ClientId, appSettings.Discord.ClientSecret, appSettings.Discord.RedirectUri));

--- a/MakiseSharpServer.API/MakiseSharpServer.API.csproj
+++ b/MakiseSharpServer.API/MakiseSharpServer.API.csproj
@@ -1,13 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 	<CodeAnalysisRuleSet>..\RuleSet.ruleset</CodeAnalysisRuleSet>
+	<UserSecretsId>59a4738e-24ba-4fbb-9492-e7441fee8215</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +36,7 @@
     <PackageReference Include="Refit" Version="4.6.58" />
     <PackageReference Include="Refit.HttpClientFactory" Version="4.6.58" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MakiseSharpServer.API/MakiseSharpServer.API.csproj
+++ b/MakiseSharpServer.API/MakiseSharpServer.API.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="4.5.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MakiseSharpServer.API/MakiseSharpServer.API.csproj
+++ b/MakiseSharpServer.API/MakiseSharpServer.API.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Refit.HttpClientFactory" Version="4.6.58" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="4.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MakiseSharpServer.API/MakiseSharpServer.API.csproj
+++ b/MakiseSharpServer.API/MakiseSharpServer.API.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 	<CodeAnalysisRuleSet>..\RuleSet.ruleset</CodeAnalysisRuleSet>
-	<UserSecretsId>59a4738e-24ba-4fbb-9492-e7441fee8215</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/MakiseSharpServer.API/Startup.cs
+++ b/MakiseSharpServer.API/Startup.cs
@@ -47,6 +47,9 @@ namespace MakiseSharpServer.API
                 c.EnableAnnotations();
 
                 c.OperationFilter<JsonResponseOperationFilter>();
+                c.OperationFilter<MessageResultExampleOperationFilter>();
+                c.DocumentFilter<MessageResultSchemaOverrideDocumentFilter>();
+                //NOTE: using c.MapType<MessageResult> didn't seem to affect definition
             });
 
             var settings = Configuration.Get<AppSettings>();

--- a/MakiseSharpServer.API/Startup.cs
+++ b/MakiseSharpServer.API/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using MakiseSharpServer.API.Swagger.Filters;
 using MakiseSharpServer.Application.ApiClients.DiscordApi;
 using MakiseSharpServer.Application.Authentication.Commands.CreateToken;
 using MakiseSharpServer.Application.Authentication.Services;
@@ -44,6 +45,8 @@ namespace MakiseSharpServer.API
                 c.IncludeXmlComments(xmlPath);
 
                 c.EnableAnnotations();
+
+                c.OperationFilter<JsonResponseOperationFilter>();
             });
 
             var settings = Configuration.Get<AppSettings>();

--- a/MakiseSharpServer.API/Startup.cs
+++ b/MakiseSharpServer.API/Startup.cs
@@ -42,6 +42,8 @@ namespace MakiseSharpServer.API
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
                 c.IncludeXmlComments(xmlPath);
+
+                c.EnableAnnotations();
             });
 
             var settings = Configuration.Get<AppSettings>();

--- a/MakiseSharpServer.API/Startup.cs
+++ b/MakiseSharpServer.API/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using MakiseSharpServer.API.Swagger.Examples;
 using MakiseSharpServer.API.Swagger.Filters;
 using MakiseSharpServer.Application.ApiClients.DiscordApi;
 using MakiseSharpServer.Application.Authentication.Commands.CreateToken;
@@ -17,6 +18,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Refit;
+using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace MakiseSharpServer.API
@@ -45,6 +47,7 @@ namespace MakiseSharpServer.API
                 c.IncludeXmlComments(xmlPath);
 
                 c.EnableAnnotations();
+                c.ExampleFilters();
 
                 c.OperationFilter<JsonResponseOperationFilter>();
                 c.OperationFilter<MessageResultExampleOperationFilter>();
@@ -72,6 +75,7 @@ namespace MakiseSharpServer.API
             services.AddMediatR(typeof(CreateTokenCommandHandler));
             services.AddRefitClient<IDiscordApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = settings.Discord.ApiUri);
+            services.AddSwaggerExamplesFromAssemblyOf<JwtResponseExample>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/MakiseSharpServer.API/Swagger/Examples/JwtResponseExample.cs
+++ b/MakiseSharpServer.API/Swagger/Examples/JwtResponseExample.cs
@@ -1,0 +1,14 @@
+﻿using MakiseSharpServer.Application.Authentication.Models;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace MakiseSharpServer.API.Swagger.Examples
+{
+    public class JwtResponseExample : IExamplesProvider<JwtResponse>
+    {
+        public JwtResponse GetExamples()
+        {
+            var accessToken = new AccessToken("abcdxyz123", 5);
+            return new JwtResponse(accessToken, "qwertyu123");
+        }
+    }
+}

--- a/MakiseSharpServer.API/Swagger/Filters/JsonResponseOperationFilter.cs
+++ b/MakiseSharpServer.API/Swagger/Filters/JsonResponseOperationFilter.cs
@@ -1,0 +1,17 @@
+﻿using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MakiseSharpServer.API.Swagger.Filters
+{
+    /// <summary>
+    /// Sets all operations' response types to application/json
+    /// </summary>
+    public class JsonResponseOperationFilter : IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            operation.Produces.Clear();
+            operation.Produces.Add("application/json");
+        }
+    }
+}

--- a/MakiseSharpServer.API/Swagger/Filters/MessageResultExampleOperationFilter.cs
+++ b/MakiseSharpServer.API/Swagger/Filters/MessageResultExampleOperationFilter.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Reflection;
+using MakiseSharpServer.API.Results;
+using Newtonsoft.Json.Linq;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MakiseSharpServer.API.Swagger.Filters
+{
+    /// <summary>
+    /// When an operation is decorated with <see cref="SwaggerResponseAttribute"/> and has a
+    /// description, the description will be used as an example response for MessageResult json response
+    /// </summary>
+    public class MessageResultExampleOperationFilter : IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var attributes = context.MethodInfo.GetCustomAttributes().OfType<SwaggerResponseAttribute>();
+            foreach (var attribute in attributes)
+            {
+                if (attribute.StatusCode >= 400 && attribute.Description != null)
+                {
+                    dynamic message = new JObject();
+                    message.message = attribute.Description;
+                    var json = new JObject(new JProperty("application/json", message));
+                    operation.Responses[attribute.StatusCode.ToString()].Examples = json;
+
+                    operation.Responses[attribute.StatusCode.ToString()].Schema =
+                        context.SchemaRegistry.GetOrRegister(typeof(MessageResult));
+                }
+            }
+        }
+    }
+}

--- a/MakiseSharpServer.API/Swagger/Filters/MessageResultSchemaOverrideDocumentFilter.cs
+++ b/MakiseSharpServer.API/Swagger/Filters/MessageResultSchemaOverrideDocumentFilter.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using MakiseSharpServer.API.Results;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MakiseSharpServer.API.Swagger.Filters
+{
+    /// <summary>
+    /// Replaces MessageResult junk schema with the correct one (just one string message property)
+    /// </summary>
+    public class MessageResultSchemaOverrideDocumentFilter : IDocumentFilter
+    {
+        public void Apply(SwaggerDocument swaggerDoc, DocumentFilterContext context)
+        {
+            var schema = new Schema { Type = "object" };
+
+            var messageSchema = new Schema
+            {
+                Type = "string",
+                ReadOnly = true
+            };
+            schema.Properties = new Dictionary<string, Schema> { { "message", messageSchema } };
+            swaggerDoc.Definitions[nameof(MessageResult)] = schema;
+
+            swaggerDoc.Definitions.Remove(nameof(IOutputFormatter)); //left after the old MessageResult schema
+        }
+    }
+}


### PR DESCRIPTION
Closes #3 
- Added xml docs
- Added `SwaggerResponseAttribute` annotations
The description of `SwaggerResponseAttribute` is used to make an example error query when the returned status code >= 400
- swagger.json available at /api/v1/swagger.json
- SwaggerUI in dev env
- Operation filter to remove response content-type bloat such as text/json etc.
- Operation filter to generate swagger examples from attributes
- Document filter to change the schema of MessageResult to only include one property: string "message"

**In the future:**
- Returned messages SHOULD be equal to those in SwaggerResponseAttributes in order to create correct examples